### PR TITLE
Allowed stable toolchain compilation and allowed general dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ description = "A rusty implementation of the weird-ass special number type used 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.99", features = ["derive"] }
-num-traits = "0.2.8"
-
-regex = "1.2.1"
-lazy_static = "1.4.0"
+serde = { version = "^1", features = ["derive"] }
+num-traits = "^0.2"
+regex = "^1"
+lazy_static = "^1"
 
 [dev-dependencies]
-serde_json = "1.0.40"
+serde_json = "^1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-// So we don't have _horrible_ trait bounds
-#![feature(trait_alias)]
-
 #[cfg(test)]
 mod tests;
 

--- a/src/number/ops.rs
+++ b/src/number/ops.rs
@@ -329,5 +329,3 @@ impl<T: YololOps> Not for YololNumber<T>
         }
     }
 }
-
-

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -8,18 +8,31 @@ pub use yolol_ops::YololOps;
 /// Trait bounds for the various operations required for a compliant
 /// YololOps implementation. Requires ArgBounds<Self>, implying the type
 /// can be used as an argument for a YololNumber backed by itself.
-pub trait InnerBounds =
+pub trait InnerBounds:
     // These are just the bounds required to get YololOps implemented correctly
     ArgBounds<Self> + Signed + Bounded + CheckedAdd + CheckedSub + CheckedMul + CheckedDiv + CheckedRem + One + Zero + PartialOrd
 
     // These bounds are regular convenience ones that makes numbers behave nicer
-    + Eq + PartialEq + Ord + FromStr;
+    + Eq + PartialEq + Ord + FromStr {}
+
+impl<T:
+    ArgBounds<Self> + Signed + Bounded + CheckedAdd + CheckedSub + CheckedMul + 
+    CheckedDiv + CheckedRem + One + Zero + PartialOrd +
+    Eq + PartialEq + Ord + FromStr>
+InnerBounds for T {}
 
 /// Trait bounds extending from NumBounds to allow the type to be
 /// an argument to a YololNumber<T>.
-pub trait ArgBounds<T: 'static + Copy + NumBounds> = NumBounds + AsPrimitive<T>;
+pub trait ArgBounds<T: 'static + Copy + NumBounds>: NumBounds + AsPrimitive<T> {}
+
+impl<T, U> ArgBounds<T> for U
+where T: 'static + Copy + NumBounds,
+      U: NumBounds + AsPrimitive<T>
+{}
 
 /// Standard traits considered the base of any types interacting
 /// with a YololNumber. Generally isn't used itself, as it's transitively
 /// a bound for `ArgBounds` and `NumBounds`.
-pub trait NumBounds = Display + Debug + NumCast;
+pub trait NumBounds: Display + Debug + NumCast {}
+
+impl<T: Display + Debug + NumCast> NumBounds for T {}


### PR DESCRIPTION
Firstly, I removed a minor aesthetic dependency on non-stable features. Secondly, I updated Cargo.toml to be able to use newer but compatible crate versions.